### PR TITLE
Fixes from Brian Wolff

### DIFF
--- a/Score.i18n.php
+++ b/Score.i18n.php
@@ -37,26 +37,29 @@ $messages = array();
 $messages['en'] = array(
 	'score-chdirerr' => 'Unable to change directory',
 	'score-cleanerr' => 'Unable to clean out old files before re-rendering',
-	'score-compilererr' => 'Unable to compile LilyPond input file:',
+	'score-compilererr' => 'Unable to compile LilyPond input file:
+$1',
 	'score-desc' => 'MediaWiki tag extension for rendering musical scores with LilyPond',
 	'score-getcwderr' => 'Unable to obtain current working directory',
 	'score-nooutput' => 'Failed to create LilyPond image dir',
 	'score-nofactory' => 'Failed to create LilyPond factory dir',
 	'score-noinput' => 'Failed to create LilyPond input file',
-	'score-page' => 'Page',
+	'score-page' => 'Page $1',
 	'score-renameerr' => 'Error moving score files to upload directory',
 	'score-trimerr' => 'Image could not be trimmed. Set $wgScoreTrim=false if this problem persists.',
+	'score-notexecutable' => 'Could not execute LilyPond. Make sure <code>$wgLilyPond</code> is set correctly.',
 );
 
 /* Descriptish */
 $messages['qqq'] = array(
 	'score-chdirerr' => 'Displayed if the extension cannot change its working directory.',
 	'score-cleanerr' => 'Displayed if an old file cleanup operation fails.',
-	'score-compilererr' => 'Displayed if the LilyPond code could not be compiled.',
+	'score-compilererr' => 'Displayed if the LilyPond code could not be compiled. $1 is the error (generally big block of text in a pre tag)',
 	'score-desc' => '{{desc}}',
 	'score-getcwderr' => 'Displayed if the extension cannot obtain the CWD.',
 	'score-noinput' => 'Displayed if the LilyPond input file cannot be created.',
-	'score-page' => 'The word "Page" as used in pagination.',
+	'score-page' => 'The word "Page" as used in pagination. $1 is the page number',
 	'score-renameerr' => 'Displayed if moving the resultant files from the working environment to the upload directory fails.',
 	'score-trimerr' => 'Displayed if the extension failed to trim an output image.',
+	'score-notexecutable' => 'Displayed if LilyPond binary can\'t be executed.',
 );

--- a/Score.php
+++ b/Score.php
@@ -42,8 +42,11 @@ if ( !defined( 'MEDIAWIKI' ) ) {
  * Configuration
  */
 
-/* Whether to trim the score images. Requires ImageMagick. Default is yes. */
-$wgScoreTrim = true;
+/* Whether to trim the score images. Requires ImageMagick.
+ *  Default is $wgUseImageMagick and set in efScoreExtension */
+$wgScoreTrim = null;
+/* Path of lilypond executable */
+$wgLilyPond = '/usr/bin/lilypond';
 
 /*
  * Extension credits
@@ -72,19 +75,11 @@ $wgAutoloadClasses['Score'] = dirname( __FILE__ ) . '/Score.body.php';
  * @return true if initialisation was successful, false otherwise.
  */
 function efScoreExtension( Parser &$parser ) {
-	global $wgUseImageMagick, $wgLilyPond, $wgScoreTrim;
+	global $wgUseImageMagick, $wgScoreTrim;
 
-	if ( !is_executable( $wgLilyPond ) ) {
-		wfDebugLog( 'Score', "Set LilyPond file \$wgLilyPond=$wgLilyPond is not executable.\n" );
-		return false;
-	}
-	if ( !isset( $wgScoreTrim ) ) {
-		wfDebugLog( 'Score', "Required global variable \$wgScoreTrim not set.\n" );
-		return false;
-	}
-	if ( $wgScoreTrim && !$wgUseImageMagick ) {
-		wfDebugLog( 'Score', "Score trimming requested, but ImageMagick is unavailable.\n" );
-		return false;
+	if ( $wgScoreTrim === null ) {
+		// Default to if we use Image Magick, since it requires Image Magick.
+		$wgScoreTrim = $wgUseImageMagick;
 	}
 
 	$parser->setHook( 'score', 'Score::render' );


### PR DESCRIPTION
- $wgLilyPond needs to default to something even if we expect user to
  set it.
- Make $wgScoreTrim default to $wgUseImageMagick.  I didn't like the
  check to error out if $wgUseImageMagick was false, because someone
  could have ImageMagick installed, but not want to use it for image
  rendering.
- Switch the checks done in ParserFirstCallInit to be in the main
  rendering code since returning false from ParserFirstCallInit is a
  _really_ bad idea. It stops all other extensions from loading, and
  the end user won't know why.
  
  This also means that we only check if $wgLilyPond is executable when
  we actually have <score> tags to parse.
- For messages: since this is a parser hook, the messages are stored
  in the parser cache, so we have to use the wiki's content language,
  not the user language or the next person will get errors in wrong
  language.
- Some of the messages should use parameters.  This is especially
  important for the "Page: 1" message, since that message may need
  plural processing and digit conversion in some languages.
- Wrap most of the error messages in <span class=error>. This is the
  convention for error messages, and makes them red.
  
  I didn't do that for the compile-error message.  But perhaps it
  should also be put in the <span class=error>, at least for the intro
  part.
